### PR TITLE
Enhance/linux compatibility

### DIFF
--- a/R/global.R
+++ b/R/global.R
@@ -570,8 +570,8 @@ launch_application <- function() {
 #'
 #' @return launches app
 #' @export launch_application_browser
-launch_application_browser <- function( launchBrowser = TRUE ) {
-  shiny::runApp(appDir = system.file("application", package = "facetsPreview"), launch.browser = launchBrowser)
+launch_application_browser <- function() {
+  shiny::runApp(appDir = system.file("application", package = "facetsPreview"), launch.browser = TRUE)
 }
 
 require(bit64)

--- a/R/global.R
+++ b/R/global.R
@@ -570,8 +570,8 @@ launch_application <- function() {
 #'
 #' @return launches app
 #' @export launch_application_browser
-launch_application_browser <- function() {
-  shiny::runApp(appDir = system.file("application", package = "facetsPreview"), launch.browser = TRUE)
+launch_application_browser <- function( launchBrowser = TRUE ) {
+  shiny::runApp(appDir = system.file("application", package = "facetsPreview"), launch.browser = launchBrowser)
 }
 
 require(bit64)

--- a/inst/application/server.R
+++ b/inst/application/server.R
@@ -71,8 +71,10 @@ function(input, output, session) {
       
       cur_time = as.numeric(system(" date +%s ", intern=TRUE))
       if (Sys.info()['sysname'] == "Linux" ) { 
-	      last_mod = as.numeric(system(paste0("stat -c %Y ", values$config$watcher_dir, "/watcher.log"), intern=TRUE)) 
-      } else { last_mod = as.numeric(system(paste0("stat -f%c ", values$config$watcher_dir, "/watcher.log"), intern=TRUE)) }
+	last_mod = as.numeric(system(paste0("stat -c %Y ", values$config$watcher_dir, "/watcher.log"), intern=TRUE)) 
+      } else { 
+	last_mod = as.numeric(system(paste0("stat -f%c ", values$config$watcher_dir, "/watcher.log"), intern=TRUE)) 
+      }
       
       if ( cur_time - last_mod < 900) {
         values$watcher_status = T

--- a/inst/application/server.R
+++ b/inst/application/server.R
@@ -70,7 +70,9 @@ function(input, output, session) {
       }
       
       cur_time = as.numeric(system(" date +%s ", intern=TRUE))
-      last_mod = as.numeric(system(paste0("stat -f%c ", values$config$watcher_dir, "/watcher.log"), intern=TRUE))
+      if (Sys.info()['sysname'] == "Linux" ) { 
+	      last_mod = as.numeric(system(paste0("stat -c %Y ", values$config$watcher_dir, "/watcher.log"), intern=TRUE)) 
+      } else { last_mod = as.numeric(system(paste0("stat -f%c ", values$config$watcher_dir, "/watcher.log"), intern=TRUE)) }
       
       if ( cur_time - last_mod < 900) {
         values$watcher_status = T


### PR DESCRIPTION
Adding alternative statement for when the os system is linux to execute `stat` with appropriate parameters. 
The issue is that 
`stat -f%c /path/to/file` 
works on Mac, while on linux these are invalid parameters even though `stat` exists as a related software on linux. Instead,
`stat -c %Y /path/to/file` 
must be used.